### PR TITLE
Metadata tests

### DIFF
--- a/scripts/metadata/metadata.py
+++ b/scripts/metadata/metadata.py
@@ -33,3 +33,51 @@ class TaskDescription:
 
         return task
 
+import json
+
+class TaskOutputDescription:
+    def __init__(self, task_name, task_description):
+        self.task_name = task_name
+        self.task_description = task_description
+        self.output_files = []
+        self.logs = []
+        self.status = ""
+
+    def add_output_file(self, file_name, file_type):
+        self.output_files.append({"file_name": file_name, "file_type": file_type})
+
+    def add_log_file(self, log_name):
+        self.logs.append(log_name)
+
+    def set_status(self, status):
+        self.status = status
+
+    def save_to_json(self, filename):
+        data = {
+            "task_name": self.task_name,
+            "task_description": self.task_description,
+            "output_files": self.output_files,
+            "logs": self.logs,
+            "status": self.status
+        }
+
+        with open(filename, "w") as file:
+            json.dump(data, file, indent=4)
+
+    @classmethod
+    def load_from_json(cls, filename):
+        with open(filename, "r") as file:
+            data = json.load(file)
+
+        task_name = data["task_name"]
+        task_description = data["task_description"]
+        output_files = data["output_files"]
+        logs = data["logs"]
+        status = data["status"]
+
+        task_output = cls(task_name, task_description)
+        task_output.output_files = output_files
+        task_output.logs = logs
+        task_output.status = status
+
+        return task_output

--- a/scripts/tests/test_metadata.py
+++ b/scripts/tests/test_metadata.py
@@ -15,6 +15,7 @@ absolute_list[-1] = "metadata/"
 sys.path.append("/".join(absolute_list))
 
 from metadata import TaskDescription
+from metadata import TaskOutputDescription
 
 @pytest.fixture
 def sample_task():
@@ -48,3 +49,42 @@ def test_save_and_load_json_file_content(sample_task, tmp_path):
     assert loaded_data['task_name'] == sample_task.task_name
     assert loaded_data['task_description'] == sample_task.task_description
     assert loaded_data['parameters'] == sample_task.parameters
+
+@pytest.fixture
+def sample_output_task():
+    task = TaskOutputDescription('Task_Gain', 'Image format conversion task')
+    task.add_output_file('job/Gain.tiff', 'tiff')
+    task.add_log_file('tif2mrc.stdout')
+    task.add_log_file('tif2mrc.stderr')
+    task.set_status('Success')
+    return task
+
+def test_output_save_and_load_json(sample_output_task, tmp_path):
+    filename = tmp_path / 'task_output_description.json'
+    sample_output_task.save_to_json(str(filename))
+
+    # Load task from JSON
+    loaded_task = TaskOutputDescription.load_from_json(str(filename))
+
+    # Check saved values
+    assert loaded_task.task_name == sample_output_task.task_name
+    assert loaded_task.task_description == sample_output_task.task_description
+    assert loaded_task.output_files == sample_output_task.output_files
+    assert loaded_task.logs == sample_output_task.logs
+    assert loaded_task.status == sample_output_task.status
+
+def test_output_save_and_load_json_file_content(sample_output_task, tmp_path):
+    # Save task to JSON
+    filename = tmp_path / 'task_output_description.json'
+    sample_output_task.save_to_json(str(filename))
+
+    # Load JSON file and compare its content
+    with open(filename, 'r') as file:
+        loaded_data = json.load(file)
+
+    assert loaded_data['task_name'] == sample_output_task.task_name
+    assert loaded_data['task_description'] == sample_output_task.task_description
+    assert loaded_data['output_files'] == sample_output_task.output_files
+    assert loaded_data['logs'] == sample_output_task.logs
+    assert loaded_data['status'] == sample_output_task.status
+


### PR DESCRIPTION
This set of changes is to start creating a pair of metadata JSON files for every task.

1. The first metadata would be created when a task is run, and would include all the parameters as name:value pairs used in running the task.  It would also define what the task was and any other general descriptive values.
2. The second metadata would be created when a task completes (which might happen from different possible status outcomes of success, aborted, or failed).  

The first metadata would be useful for the UI, and tracking how things are run.  This should allow one to 'rerun' a task later or clone a task with the same parameters and setup.

The second metadata will be useful to view the outcome in the UI, and to hopefully chain the output results from one task as inputs into another task.  On the `TaskOutputDescription`, I have defined that the output files would have a `file_type` that might be checked when trying to use as input into the next task.

This is all a "first-pass" at defining task metadata, and open for ideas and additions.