### PR TITLE
Ability to call the TaskImport via UI, end-to-end and create the Task…

### DIFF
--- a/api/fixtures/tasks.json
+++ b/api/fixtures/tasks.json
@@ -7,5 +7,14 @@
 		"description": "Convert dm4 to mrc format",
 		"parameter_fields": "[{\"name\":\"Input File\",\"type\":\"file\",\"default\":null}]"
 	  }
-	}
+    },
+    {
+        "model": "api.Task",
+        "pk": 2,
+        "fields": {
+            "name": "Import",
+            "description": "Import micrographs into a project",
+            "parameter_fields": "[{\"name\":\"import_data\",\"type\":\"directory\",\"default\":null}, {\"name\":\"import_directory_type\",\"type\":\"string\",\"default\":\"frames\"}]"
+        }
+    }
   ]

--- a/api/taskwrapper.py
+++ b/api/taskwrapper.py
@@ -5,11 +5,16 @@ import pytz
 import os
 from datetime import datetime
 from scripts.program.task_gain import TaskGain
+from scripts.program.task_import import TaskImport
 from django.conf import settings
+
+import scripts.program.scripts_constants as CONSTANTS
 
 def task_handler(project_task, run):
     if project_task.task.name == "Gain":
         task_gain_handler(project_task, run)
+    elif project_task.task.name == "Import":
+        task_import_handler(project_task, run)
     else:
         task_sample_handler(project_task, run)
 
@@ -66,14 +71,23 @@ def task_sample_handler(project_task, run):
     run.save()
         
 def task_gain_handler(project_task, run):
+    project = project_task.project
+    # TODO: ideally parameters would provide name:value pairs as a dictionary? We only get the values.
+    parameters = json.loads(project_task.parameter_values)
+    input_file = parameters[0]
+
     logs = []
     logs.append({
         "timestamp": str(datetime.now().replace(tzinfo=pytz.utc)),
         "detail": "Running Gain task...",
     })
-    task_gain = TaskGain(os.path.join(settings.BASE_DIR, "scripts/tests/TestData/Gain/test1"), "input.dm4")
+
+    project_folder = os.path.join( project.folder_path, CONSTANTS.TASK_FOLDER_PREFIX + str(project_task.id) )
+
+    task_gain = TaskGain(project_folder, input_file)
     task_gain.run()
-    run.status = "SUCCESS"
+
+    run.status = task_gain.get_result().status
     run.end_time = datetime.now().replace(tzinfo=pytz.utc)
     logs.append({
         "timestamp": str(datetime.now().replace(tzinfo=pytz.utc)),
@@ -83,3 +97,33 @@ def task_gain_handler(project_task, run):
     run.errors = json.dumps([])
     run.save()
 
+def task_import_handler(project_task, run):
+    project = project_task.project
+    # TODO: ideally parameters would provide name:value pairs as a dictionary? We only get the values.
+    parameters = json.loads(project_task.parameter_values)
+
+    logs = []
+    logs.append({
+        "timestamp": str(datetime.now().replace(tzinfo=pytz.utc)),
+        "detail": "Running Import task...",
+    })
+
+    project_folder = os.path.join( project.folder_path, CONSTANTS.TASK_FOLDER_PREFIX + str(project_task.id) )
+    print("Will create at: " + project_folder)
+
+    print(parameters)
+    task_import = TaskImport(project_folder)
+    # TODO: if we can get name:value dictionary from the JSON string, this could be simplified here?
+    task_import.parameters['import_data'] = parameters[0]
+    task_import.parameters['import_directory_type'] = parameters[1]
+    task_import.run()
+    
+    run.status = task_import.get_result().status
+    run.end_time = datetime.now().replace(tzinfo=pytz.utc)
+    logs.append({
+        "timestamp": str(datetime.now().replace(tzinfo=pytz.utc)),
+        "detail": "Import task run completed successfully"
+    })
+    run.logs = json.dumps(logs)
+    run.errors = json.dumps([])
+    run.save()

--- a/scripts/program/scripts_constants.py
+++ b/scripts/program/scripts_constants.py
@@ -15,6 +15,13 @@ TASKS: (task_name: task_absolute_path) key-value pairs
 TASK_NUM = "task_num"
 PROJECT_ID = "project_id"
 TASKS = "tasks"
+TASK_FOLDER_PREFIX = "task_"
+
+# CREATED, RUNNING, SUCCESS, FAILED
+TASK_STATUS_CREATED = "CREATED"
+TASK_STATUS_SUCCESS =  "SUCCESS"
+TASK_STATUS_RUNNING = "RUNNING"
+TASK_STATUS_FAILED = "FAILED"
 
 """
 Contents inside task folder

--- a/scripts/program/task_import.py
+++ b/scripts/program/task_import.py
@@ -5,6 +5,8 @@ from scripts.program.metadata.image_metadata import ImageMetadata, ImageSet
 from scripts.program.metadata.task_metadata import TaskDescription, TaskOutputDescription
 from scripts.program.task import Task
 
+import scripts.program.scripts_constants as CONSTANTS
+
 def list_suffix(directory, extension):
     return (f for f in os.listdir(directory) if f.endswith('.' + extension))
 
@@ -91,9 +93,9 @@ class TaskImport(Task):
 
     def run(self):
         """ Should run the import task """
-        if not self.parameters['import_data']:
+        if not 'import_data' in self.parameters.keys():
             raise ValueError("Parameter 'import_data' is not provided")
-        if not self.parameters['import_directory_type']:
+        if not 'import_directory_type' in self.parameters.keys():
             raise ValueError("Parameter 'import_directory_type' is not provided")
 
         # Create a TaskDescription with parameters.
@@ -116,6 +118,7 @@ class TaskImport(Task):
 
         #  Serialize the `result.json` metadata file that points to `imageset.json`
         results_json_path = os.path.join(self.task_folder, self.result_json)
+        results.status = CONSTANTS.TASK_STATUS_SUCCESS 
         results.save_to_json(results_json_path)
 
     def name(self) -> str:


### PR DESCRIPTION
This commit now adds the "Import" task to the UI, and shows how it can call to the backend.

New tasks are able to be shown in the Django UI after you got to the main project (TomoFlows) src directory and run this command: `python manage.py loaddata api/fixtures/tasks.json`

This will update a database table to to include the tasks, and their defined parameters.

This task will run an import successfully, creating metadata describing what files were imported and then pass the "SUCCESS" value back to the UI task runner that updates the UI to show the task did complete.