### PR TITLE
Each instance of 'TomoFlows' will generate a new SECRET_KEY, excluded…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ TestData/
 
 # Static frontend file
 static/
+
+# Exclude a generated SECRET_KEY file
+server/secret_key.py

--- a/server/settings.py
+++ b/server/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 from pathlib import Path
 from datetime import timedelta
 
+import os
+from django.core.management.utils import get_random_secret_key
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -21,8 +23,22 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'fe$f8us8q&fou12on0scsfv*v5kohv%b69)^lc-&b365d@qvq('
+# Each instance of the TomoFlows Django project should have a unique secret_key
+# Below will create a secret key, and .gitignore excludes server/secret_key.py
+def generate_secret_key(filename):
+    secret = get_random_secret_key()
+    try:
+        with open(filename, 'w') as file:
+            file.write('SECRET_KEY = \"' + secret + '\"\n')
+    except IOError as e:
+        print(f"An error occurred while writing the file: {e}")
+
+try:
+    from .secret_key import SECRET_KEY
+except ImportError:
+    SETTINGS_DIR = os.path.abspath(os.path.dirname(__file__))
+    generate_secret_key(os.path.join(SETTINGS_DIR, 'secret_key.py'))
+    from .secret_key import SECRET_KEY
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
This change is designed to act as a fix to avoid security issues with sharing a Django "SECRET_KEY".

Instead of having a SECRET_KEY in the committed files, an excluded file from the REPO will be automatically generated on the first run of the `Django manage.py run server`, and the key is imported to be used.

Note: this change will invalidate CSRF tokens and sessions.  You may need to do two changes after getting this modified settings.py, if you having previously run a local instance with the other SECRET_KEY.

1. Clear your browser cache and cookies
2. Run `django manage.py clearsessions` to clear sessions stored in the local database (https://docs.djangoproject.com/en/4.2/topics/http/sessions/)


